### PR TITLE
Added Gyro Source to DualJoycon Configuration

### DIFF
--- a/testapp/src/JoyConDecoder.cpp
+++ b/testapp/src/JoyConDecoder.cpp
@@ -176,7 +176,7 @@ DS4_REPORT_EX GenerateDS4Report(const std::vector<uint8_t>& buffer, JoyConSide s
     return report;
 }
 
-DS4_REPORT_EX GenerateDualJoyConDS4Report(const std::vector<uint8_t>& leftBuffer, const std::vector<uint8_t>& rightBuffer)
+DS4_REPORT_EX GenerateDualJoyConDS4Report(const std::vector<uint8_t>& leftBuffer, const std::vector<uint8_t>& rightBuffer, GyroSource gyroSource)
 {
     DS4_REPORT_EX report{};
     DS4_REPORT_INIT(reinterpret_cast<PDS4_REPORT>(&report.Report));
@@ -236,19 +236,45 @@ DS4_REPORT_EX GenerateDualJoyConDS4Report(const std::vector<uint8_t>& leftBuffer
     report.Report.bThumbRX = rightReport.Report.bThumbLX;
     report.Report.bThumbRY = rightReport.Report.bThumbLY;
 
-    auto combine_16 = [](int16_t a, int16_t b) -> int16_t {
-        if (a == 0) return b;
-        if (b == 0) return a;
-        return static_cast<int16_t>((a / 2) + (b / 2));
-        };
+    switch (gyroSource) {
+        case GyroSource::Left:
+            report.Report.wAccelX = leftReport.Report.wAccelX;
+            report.Report.wAccelY = leftReport.Report.wAccelY;
+            report.Report.wAccelZ = leftReport.Report.wAccelZ;
 
-    report.Report.wAccelX = combine_16(leftReport.Report.wAccelX, rightReport.Report.wAccelX);
-    report.Report.wAccelY = combine_16(leftReport.Report.wAccelY, rightReport.Report.wAccelY);
-    report.Report.wAccelZ = combine_16(leftReport.Report.wAccelZ, rightReport.Report.wAccelZ);
+            report.Report.wGyroX = leftReport.Report.wGyroX;
+            report.Report.wGyroY = leftReport.Report.wGyroY;
+            report.Report.wGyroZ = leftReport.Report.wGyroZ;
+            break;
 
-    report.Report.wGyroX = combine_16(leftReport.Report.wGyroX, rightReport.Report.wGyroX);
-    report.Report.wGyroY = combine_16(leftReport.Report.wGyroY, rightReport.Report.wGyroY);
-    report.Report.wGyroZ = combine_16(leftReport.Report.wGyroZ, rightReport.Report.wGyroZ);
+        case GyroSource::Right:
+            report.Report.wAccelX = rightReport.Report.wAccelX;
+            report.Report.wAccelY = rightReport.Report.wAccelY;
+            report.Report.wAccelZ = rightReport.Report.wAccelZ;
+
+            report.Report.wGyroX = rightReport.Report.wGyroX;
+            report.Report.wGyroY = rightReport.Report.wGyroY;
+            report.Report.wGyroZ = rightReport.Report.wGyroZ;
+            break;
+
+        case GyroSource::Both:
+        default:
+            auto combine_16 = [](int16_t a, int16_t b) -> int16_t {
+                if (a == 0) return b;
+                if (b == 0) return a;
+                return static_cast<int16_t>((a / 2) + (b / 2));
+                };
+
+            report.Report.wAccelX = combine_16(leftReport.Report.wAccelX, rightReport.Report.wAccelX);
+            report.Report.wAccelY = combine_16(leftReport.Report.wAccelY, rightReport.Report.wAccelY);
+            report.Report.wAccelZ = combine_16(leftReport.Report.wAccelZ, rightReport.Report.wAccelZ);
+
+            report.Report.wGyroX = combine_16(leftReport.Report.wGyroX, rightReport.Report.wGyroX);
+            report.Report.wGyroY = combine_16(leftReport.Report.wGyroY, rightReport.Report.wGyroY);
+            report.Report.wGyroZ = combine_16(leftReport.Report.wGyroZ, rightReport.Report.wGyroZ);
+            break;
+    }
+
 
     return report;
 }

--- a/testapp/src/JoyConDecoder.h
+++ b/testapp/src/JoyConDecoder.h
@@ -7,6 +7,7 @@
 
 enum class JoyConSide { Left, Right };
 enum class JoyConOrientation { Upright, Sideways };
+enum class GyroSource { Both, Left, Right };
 
 struct StickData {
     int16_t x;
@@ -22,7 +23,7 @@ struct MotionData {
 
 // Pass side and orientation explicitly now:
 DS4_REPORT_EX GenerateDS4Report(const std::vector<uint8_t>& buffer, JoyConSide side, JoyConOrientation orientation);
-DS4_REPORT_EX GenerateDualJoyConDS4Report(const std::vector<uint8_t>& leftBuffer, const std::vector<uint8_t>& rightBuffer);
+DS4_REPORT_EX GenerateDualJoyConDS4Report(const std::vector<uint8_t>& leftBuffer, const std::vector<uint8_t>& rightBuffer, GyroSource gyroSource);
 DS4_REPORT_EX GenerateProControllerReport(const std::vector<uint8_t>& buffer);
 DS4_REPORT_EX GenerateNSOGCReport(const std::vector<uint8_t>& buffer);
 


### PR DESCRIPTION
# Addition

Added in an option for Dual JoyCons where you can choose what JoyCon(s) to use as the source of Motion data.

* Both: The existing combination
* Left: Only Use Left JoyCon
* Right: Only Use Right JoyCon

# Use Case

JoyCon 2 gyro is great for Wii pointers! 

I wanted to use the JoyCons separately like *WiiMote & Nunchuck* (no controller grip). This felt strange when both joycons affected "aiming."

I wanted a way to make it so that only ONE of the joycons' motion data would sent the DS4 controllers motion data.

# Notes

I added a GyroSource to `PlayerConfig` but only DualJoyCon uses it. I think you could remove this field, but that would alter the flow of config prompts. It felt a bit strange to prompt for gyro source after syncing (opposed to before syncing).